### PR TITLE
Update notification handling for x5c api changes

### DIFF
--- a/demoserver/Sources/App/routes.swift
+++ b/demoserver/Sources/App/routes.swift
@@ -2,17 +2,32 @@ import Vapor
 import JWT
 import JWTKit
 
-let appleRootCert = ""
+let appleRootCert = """
+-----BEGIN CERTIFICATE-----
+MIICQzCCAcmgAwIBAgIILcX8iNLFS5UwCgYIKoZIzj0EAwMwZzEbMBkGA1UEAwwS
+QXBwbGUgUm9vdCBDQSAtIEczMSYwJAYDVQQLDB1BcHBsZSBDZXJ0aWZpY2F0aW9u
+IEF1dGhvcml0eTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UEBhMCVVMwHhcN
+MTQwNDMwMTgxOTA2WhcNMzkwNDMwMTgxOTA2WjBnMRswGQYDVQQDDBJBcHBsZSBS
+b290IENBIC0gRzMxJjAkBgNVBAsMHUFwcGxlIENlcnRpZmljYXRpb24gQXV0aG9y
+aXR5MRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzB2MBAGByqGSM49
+AgEGBSuBBAAiA2IABJjpLz1AcqTtkyJygRMc3RCV8cWjTnHcFBbZDuWmBSp3ZHtf
+TjjTuxxEtX/1H7YyYl3J6YRbTzBPEVoA/VhYDKX1DyxNB0cTddqXl5dvMVztK517
+IDvYuVTZXpmkOlEKMaNCMEAwHQYDVR0OBBYEFLuw3qFYM4iapIqZ3r6966/ayySr
+MA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMAoGCCqGSM49BAMDA2gA
+MGUCMQCD6cHEFl4aXTQY2e3v9GwOAEZLuN+yRhHFD/3meoyhpmvOwgPUnPWTxnS4
+at+qIxUCMG1mihDK1A3UT82NQz60imOlM27jbdoXt2QfyFMm+YhidDkLF1vLUagM
+6BgD56KyKA==
+-----END CERTIFICATE-----
+"""
 
 func routes(_ app: Application) throws {
     app.post("apple/notifications") { req async -> HTTPStatus in
         do {
             let notification = try req.content.decode(SignedPayload.self)
-
-            let payload = try req.application.jwt.signers.verifyJWSWithX5C(
-                notification.signedPayload,
-                as: NotificationPayload.self,
-                rootCert: appleRootCert)
+            let x5cVerifier = try X5CVerifier(rootCertificates: [appleRootCert])
+            let payload = try x5cVerifier.verifyJWS(
+                notification.signedPayload, 
+                as: NotificationPayload.self)
 
             // Add job to process and update transaction
             // Updates user's entitlements (unlocked products or features)


### PR DESCRIPTION
## Motivation / Description
When following the tutorial I hit issues (#2) trying to verify the App Store notification payload. The API used in the example didn't seem to exist in jwt-kit. After digging in to the best of my abilities, I wanted to share my solution for future consumers. 

It appears that the original code relied on an unreleased development branch of jwt-kit. As those improvements were developed further the API changed. Ultimately, the API for x5c verification was released in [jwt-kit 4.9.0](https://github.com/vapor/jwt-kit/releases/tag/4.9.0) and the PR covering this functionality can be reviewed [here](https://github.com/vapor/jwt-kit/pull/84).

## Changes introduced
- Updated the x5c verification process within the vapor route for handling App Store notifications to align with the released API as part of [jwt-kit 4.9.0](https://github.com/vapor/jwt-kit/releases/tag/4.9.0)
- Included the apple root cert to simplify for users unfamiliar with the Root Cert process and where to find them. The certificate used is [Apple Root CA - G3 Root](https://www.apple.com/certificateauthority/AppleRootCA-G3.cer) sourced from https://www.apple.com/certificateauthority/. 

## Additional comments
Please let me know if there is anything I missed or could do to improve this. I'm happy to help make updates. 
